### PR TITLE
add hide all chats tab toggle

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -36,6 +36,7 @@ most things are toggleable in `Settings → Inugram`, with sensible opinionated 
 - long-tap "chats" tab to pick folder from menu
 - folder display modes: titles / titles+icons / icons-only
 - folder unread counter modes: hide / regular / exclude muted / 🐶 exclude muted non-dms
+- hide the "all chats" tab from the folders bar
 - 🐶 dialogs fab customization: main + secondary actions, hide-on-scroll, left-side
 - 🐶 "create as supergroup" toggle in group creation
 - 🐶 deeplink / username quick-open from global search

--- a/patches/feature/hide-all-chats-tab.patch
+++ b/patches/feature/hide-all-chats-tab.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Devin AI <158243242+devin-ai-integration[bot]@users.noreply.github.com>
+Date: Wed, 13 May 2026 19:20:36 +0000
+Subject: add a "hide all chats tab" toggle to the chat folders settings page
+
+---
+ .../java/org/telegram/ui/DialogsActivity.java | 10 ++++++++++
+ .../org/telegram/ui/FiltersSetupActivity.java | 20 +++++++++++++++++++
+ 2 files changed, 30 insertions(+)
+
+diff --git a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
++++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+@@ -6826,8 +6826,13 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
+                     selectWithStableId = true;
+                 }
+                 filterTabsView.removeTabs();
++                boolean inu_hideAllChatsTab = FolderHelper.shouldHideAllChatsTab(filters);
++                if (inu_hideAllChatsTab) {
++                    filterTabsView.resetTabId();
++                }
+                 for (int a = 0, N = filters.size(); a < N; a++) {
+                     if (filters.get(a).isDefault()) {
++                        if (inu_hideAllChatsTab) continue;
+                         filterTabsView.inu_addTab(a, 0, LocaleController.getString(R.string.FilterAllChats), null, false, true, filters.get(a).locked, "\uD83D\uDCAC");
+                     } else {
+                         final MessagesController.DialogFilter filter = filters.get(a);
+@@ -6855,6 +6860,11 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
+                     if (viewPages[a].selectedType >= filters.size()) {
+                         viewPages[a].selectedType = filters.size() - 1;
+                     }
++                    int inu_adjusted = FolderHelper.adjustSelectedTypeForHide(filters, viewPages[a].selectedType);
++                    if (inu_adjusted != viewPages[a].selectedType) {
++                        viewPages[a].selectedType = inu_adjusted;
++                        if (a == 0) updateCurrentTab = true;
++                    }
+                     viewPages[a].listView.setScrollingTouchSlop(RecyclerView.TOUCH_SLOP_PAGING);
+                 }
+                 filterTabsView.finishAddingTabs(animatedUpdateItems);
+diff --git a/TMessagesProj/src/main/java/org/telegram/ui/FiltersSetupActivity.java b/TMessagesProj/src/main/java/org/telegram/ui/FiltersSetupActivity.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/ui/FiltersSetupActivity.java
++++ b/TMessagesProj/src/main/java/org/telegram/ui/FiltersSetupActivity.java
+@@ -70,6 +70,8 @@ import org.telegram.ui.Components.UndoView;
+ 
+ import java.util.ArrayList;
+ 
++import desu.inugram.helpers.FolderHelper;
++
+ public class FiltersSetupActivity extends BaseFragment implements NotificationCenter.NotificationCenterDelegate {
+ 
+     private RecyclerListView listView;
+@@ -589,6 +591,8 @@ public class FiltersSetupActivity extends BaseFragment implements NotificationCe
+         items.add(ItemInner.asShadow(!getUserConfig().isPremium() ? AndroidUtilities.replaceSingleTag(LocaleController.getString(R.string.FolderShowTagsInfoPremium), Theme.key_windowBackgroundWhiteBlueHeader, AndroidUtilities.REPLACING_TAG_TYPE_LINKBOLD, () -> {
+             presentFragment(new PremiumPreviewFragment("settings"));
+         }) : LocaleController.getString(R.string.FolderShowTagsInfo)));
++        items.add(ItemInner.inu_asHideAllChatsCheck());
++        items.add(ItemInner.asShadow(LocaleController.getString(R.string.InuHideAllChatsTabInfo)));
+ 
+         if (adapter != null) {
+             if (animated) {
+@@ -672,6 +676,10 @@ public class FiltersSetupActivity extends BaseFragment implements NotificationCe
+                 return;
+             }
+             if (item.viewType == VIEW_TYPE_CHECK) {
++                if (item.inu_hideAllChatsCheck) {
++                    ((TextCheckCell) view).setChecked(FolderHelper.toggleHideAllChatsTab());
++                    return;
++                }
+                 if (!getUserConfig().isPremium()) {
+                     showDialog(new PremiumFeatureBottomSheet(this, PremiumPreviewFragment.PREMIUM_FEATURE_FOLDER_TAGS, true));
+                     return;
+@@ -780,6 +788,7 @@ public class FiltersSetupActivity extends BaseFragment implements NotificationCe
+         MessagesController.DialogFilter filter;
+         int filterColor;
+         TLRPC.TL_dialogFilterSuggested suggested;
++        boolean inu_hideAllChatsCheck;
+ 
+         public static ItemInner asHeader(CharSequence text) {
+             ItemInner i = new ItemInner(VIEW_TYPE_HEADER);
+@@ -815,6 +824,12 @@ public class FiltersSetupActivity extends BaseFragment implements NotificationCe
+             i.text = text;
+             return i;
+         }
++        public static ItemInner inu_asHideAllChatsCheck() {
++            ItemInner i = new ItemInner(VIEW_TYPE_CHECK);
++            i.text = LocaleController.getString(R.string.InuHideAllChatsTab);
++            i.inu_hideAllChatsCheck = true;
++            return i;
++        }
+ 
+         @Override
+         public boolean equals(Object obj) {
+@@ -1070,6 +1085,11 @@ public class FiltersSetupActivity extends BaseFragment implements NotificationCe
+                 }
+                 case VIEW_TYPE_CHECK: {
+                     TextCheckCell cell = (TextCheckCell) holder.itemView;
++                    if (item.inu_hideAllChatsCheck) {
++                        cell.setTextAndCheck(item.text, desu.inugram.InuConfig.HIDE_ALL_CHATS_TAB.getValue(), divider);
++                        cell.setCheckBoxIcon(0);
++                        break;
++                    }
+                     cell.setTextAndCheck(item.text, getMessagesController().folderTags, divider);
+                     cell.setCheckBoxIcon(!getUserConfig().isPremium() ? R.drawable.permission_locked : 0);
+                     break;

--- a/series
+++ b/series
@@ -132,3 +132,4 @@ feature/hide-call-action.patch
 bugfix/top-peers-unread-counter.patch
 bugfix/stale-unread-mention.patch
 feature/forward-options.patch
+feature/hide-all-chats-tab.patch

--- a/src/kotlin/InuConfig.kt
+++ b/src/kotlin/InuConfig.kt
@@ -285,6 +285,9 @@ object InuConfig {
     @JvmField
     val FOLDERS_UNREAD_COUNTER_MODE = FoldersUnreadCounterModeItem()
 
+    @JvmField
+    val HIDE_ALL_CHATS_TAB = BoolItem("hide_all_chats_tab", false)
+
     class StickerTimeModeItem : IntItem("sticker_time_mode", SHOW) {
         companion object {
             const val SHOW = 1;

--- a/src/kotlin/helpers/FolderHelper.kt
+++ b/src/kotlin/helpers/FolderHelper.kt
@@ -12,6 +12,7 @@ import org.telegram.messenger.AndroidUtilities
 import org.telegram.messenger.LocaleController.getString
 import org.telegram.messenger.MessagesController
 import org.telegram.messenger.MessagesStorage
+import org.telegram.messenger.NotificationCenter
 import org.telegram.messenger.R
 import org.telegram.messenger.UserConfig
 import org.telegram.tgnet.TLRPC
@@ -233,5 +234,34 @@ object FolderHelper {
         if (isIconsOnly()) return FilterTabsView.TAB_INTERNAL_PADDING / 2f
         if (InuConfig.FOLDERS_DISPLAY_MODE.value == InuConfig.FoldersDisplayModeItem.TITLES_AND_ICONS) return 8f
         return FilterTabsView.TAB_INTERNAL_PADDING
+    }
+
+    /** whether the "All chats" (default) tab should be hidden from the folders bar. */
+    @JvmStatic
+    fun shouldHideAllChatsTab(filters: List<MessagesController.DialogFilter>): Boolean {
+        if (!InuConfig.HIDE_ALL_CHATS_TAB.value) return false
+        // keep showing the default tab if it is the only filter, otherwise the bar would be empty
+        return filters.any { !it.isDefault }
+    }
+
+    /** if user is currently sitting on the default filter and it's about to be hidden,
+     *  bounce them to the first non-default filter; otherwise leave the index untouched. */
+    @JvmStatic
+    fun adjustSelectedTypeForHide(filters: List<MessagesController.DialogFilter>, selectedType: Int): Int {
+        if (!shouldHideAllChatsTab(filters)) return selectedType
+        if (selectedType < 0 || selectedType >= filters.size) return selectedType
+        if (!filters[selectedType].isDefault) return selectedType
+        return filters.indexOfFirst { !it.isDefault }.coerceAtLeast(0)
+    }
+
+    /** flip the "hide all chats tab" toggle and notify dialog activities to rebuild the folders bar. */
+    @JvmStatic
+    fun toggleHideAllChatsTab(): Boolean {
+        val new = InuConfig.HIDE_ALL_CHATS_TAB.toggle()
+        for (i in 0 until UserConfig.MAX_ACCOUNT_COUNT) {
+            if (!UserConfig.getInstance(i).isClientActivated) continue
+            NotificationCenter.getInstance(i).postNotificationName(NotificationCenter.dialogFiltersUpdated)
+        }
+        return new
     }
 }

--- a/src/res/values-ru/strings_inu.xml
+++ b/src/res/values-ru/strings_inu.xml
@@ -127,6 +127,8 @@
     <string name="InuFoldersUnreadCounterRegular">Обычный</string>
     <string name="InuFoldersUnreadCounterExcludeMuted">Кроме мутов</string>
     <string name="InuFoldersUnreadCounterExcludeMutedNonDms">Кроме мутов и не из ЛС</string>
+    <string name="InuHideAllChatsTab">Скрыть вкладку «Все чаты»</string>
+    <string name="InuHideAllChatsTabInfo">Убирает вкладку «Все чаты» с панели папок. Должна быть хотя бы одна своя папка.</string>
     <string name="InuCopyPhoto">Копировать фото</string>
     <string name="InuPhotoCopied">Фото скопировано в буфер обмена</string>
     <string name="InuCopyFrame">Копировать кадр</string>

--- a/src/res/values/strings_inu.xml
+++ b/src/res/values/strings_inu.xml
@@ -127,6 +127,8 @@
     <string name="InuFoldersUnreadCounterRegular">Regular</string>
     <string name="InuFoldersUnreadCounterExcludeMuted">Exclude muted</string>
     <string name="InuFoldersUnreadCounterExcludeMutedNonDms">Exclude muted non-DMs</string>
+    <string name="InuHideAllChatsTab">Hide "All Chats" tab</string>
+    <string name="InuHideAllChatsTabInfo">Removes the "All Chats" tab from the folders bar. Requires at least one user folder.</string>
     <string name="InuCopyPhoto">Copy Photo</string>
     <string name="InuPhotoCopied">Photo copied to clipboard</string>
     <string name="InuCopyFrame">Copy Frame</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hide the "All Chats" tab from your chat folders bar. A new toggle in folder settings enables you to remove the default tab and fully customize your tab layout. When enabled, tab indices are automatically adjusted. Requires at least one user folder to be configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teidesu/inugram/pull/7)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->