### PR TITLE
fix emoji-only message size in search results

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -170,3 +170,4 @@ most things are toggleable in `Settings → Inugram`, with sensible opinionated 
 - profile scroll jump when opening uncached user
 - stale unread badges on global-search top peers
 - stale unread mention pointer after reading mention on another device (mention button jumping to old message)
+- messages consisting of only 2 or 3 emojis are huge in chat search results

--- a/patches/bugfix/search-emoji-size.patch
+++ b/patches/bugfix/search-emoji-size.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: flexagoon <code@fxgn.dev>
+Date: Fri, 15 May 2026 21:26:00 +0200
+Subject: Fix emoji-only message size in search results
+
+---
+ .../java/org/telegram/messenger/HashtagSearchController.java  | 2 +-
+ .../main/java/org/telegram/messenger/MediaDataController.java | 2 +-
+ .../src/main/java/org/telegram/messenger/MessagesStorage.java | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/TMessagesProj/src/main/java/org/telegram/messenger/HashtagSearchController.java b/TMessagesProj/src/main/java/org/telegram/messenger/HashtagSearchController.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/messenger/HashtagSearchController.java
++++ b/TMessagesProj/src/main/java/org/telegram/messenger/HashtagSearchController.java
+@@ -238,7 +238,7 @@ public class HashtagSearchController {
+                 TLRPC.messages_Messages messages = (TLRPC.messages_Messages) res;
+                 ArrayList<MessageObject> messageObjects = new ArrayList<>();
+                 for (TLRPC.Message msg : messages.messages) {
+-                    MessageObject obj = new MessageObject(currentAccount, msg, null, null, null, null, null, true, true, 0, false, false, false, searchType);
++                    MessageObject obj = new MessageObject(currentAccount, msg, null, null, null, null, null, false, true, 0, false, false, false, searchType);
+                     if (obj.hasValidGroupId()) {
+                         obj.isPrimaryGroupMessage = true;
+                     }
+diff --git a/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java b/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
++++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
+@@ -4006,7 +4006,7 @@ public class MediaDataController extends BaseController {
+                 int N = Math.min(res.messages.size(), req.limit - 1);
+                 for (int a = 0; a < N; a++) {
+                     TLRPC.Message message = res.messages.get(a);
+-                    MessageObject messageObject = new MessageObject(currentAccount, message, null, null, null, null, null, true, true, 0, false, false, isSaved);
++                    MessageObject messageObject = new MessageObject(currentAccount, message, null, null, null, null, null, false, true, 0, false, false, isSaved);
+                     if (messageObject.hasValidGroupId()) {
+                         messageObject.isPrimaryGroupMessage = true;
+                     }
+diff --git a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
++++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+@@ -5045,7 +5045,7 @@ public class MessagesStorage extends BaseController {
+                             groupmessage.readAttachPath(data, selfId);
+                             data.reuse();
+                             addUsersAndChatsFromMessage(groupmessage, usersToLoad, chatsToLoad, animatedEmojiToLoad);
+-                            MessageObject messageObject = new MessageObject(currentAccount, groupmessage, null, null, null, null, null, true, true, 0, false, false, true);
++                            MessageObject messageObject = new MessageObject(currentAccount, groupmessage, null, null, null, null, null, false, true, 0, false, false, true);
+                             if (groupmessage.reactions != null) {
+                                 messageObject.isPrimaryGroupMessage = true;
+                             }
+@@ -5074,7 +5074,7 @@ public class MessagesStorage extends BaseController {
+                                     }
+                                 }
+                             }
+-                            MessageObject messageObject = new MessageObject(currentAccount, message, null, null, null, null, null, true, true, 0, false, false, true);
++                            MessageObject messageObject = new MessageObject(currentAccount, message, null, null, null, null, null, false, true, 0, false, false, true);
+                             messageObjects.add(messageObject);
+                         }
+                     }

--- a/series
+++ b/series
@@ -132,3 +132,4 @@ feature/hide-call-action.patch
 bugfix/top-peers-unread-counter.patch
 bugfix/stale-unread-mention.patch
 feature/forward-options.patch
+bugfix/search-emoji-size.patch


### PR DESCRIPTION
Fixes emoji-only messages being too large in search results and being clipped at the bottom

Disclosure: the patch is LLM-assisted (GLM-5.1 in Pi), but manually reviewed and tested. The LLM was explicitly told to copy the behavior from global message search, which doesn't have this issue. It turned out to be a simple boolean flip in the message object constructor, so I assume this is the simplest fix.

Before:

<img width="608" height="214" alt="image" src="https://github.com/user-attachments/assets/7f25f083-3390-4e4a-8d3d-ba9201a82d07" />

After:

<img width="608" height="214" alt="image" src="https://github.com/user-attachments/assets/2aa9ea50-4a4e-4036-99a3-94945a053a3b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed emoji-only message sizing in search results—messages containing 2-3 emojis no longer render disproportionately large.
  * Updated message handling across hashtag search, media search, and message storage to apply consistent sizing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teidesu/inugram/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->