### PR TITLE
blacklist/whitelist filtering mode for paranoia

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -134,6 +134,7 @@ most things are toggleable in `Settings → Inugram`, with sensible opinionated 
 - 🐶 customizable account order
 - per-account passcodes, hidden accounts, panic code, hidden settings deeplink - *ported from [Nekogram](https://github.com/Nekogram/Nekogram)*
 - 🐶 paranoia mode: pick chats to hide everywhere; all secret chats hidden too; exit by typing a custom code in chat search
+  - blacklist or whitelist filtering mode (hide the listed chats, or show only the listed ones)
   - optionally hide the Inugram settings entirely when enabled
   - optionally disguise as stock Telegram when enabled
   - optionally silence all notifications while enabled

--- a/src/kotlin/helpers/security/ParanoiaHelper.kt
+++ b/src/kotlin/helpers/security/ParanoiaHelper.kt
@@ -26,6 +26,23 @@ object ParanoiaHelper {
     @Volatile
     private var hiddenCache: Map<Int, Set<Long>>? = null
 
+    @Volatile
+    private var visibleCache: Map<Int, Set<Long>>? = null
+
+    @Volatile
+    private var whitelistModeCache: Boolean? = null
+
+    private const val MODE_BLACKLIST = 0
+    private const val MODE_WHITELIST = 1
+
+    var isWhitelistMode: Boolean
+        get() = whitelistModeCache
+            ?: (prefs.getInt("filteringMode", MODE_BLACKLIST) == MODE_WHITELIST).also { whitelistModeCache = it }
+        set(value) {
+            prefs.edit { putInt("filteringMode", if (value) MODE_WHITELIST else MODE_BLACKLIST) }
+            whitelistModeCache = value
+        }
+
     fun isParanoia(): Boolean =
         paranoiaCache ?: prefs.getBoolean("paranoia", false).also { paranoiaCache = it }
 
@@ -33,26 +50,47 @@ object ParanoiaHelper {
     fun isHidden(account: Int, dialogId: Long): Boolean {
         if (!isParanoia()) return false
         if (DialogObject.isEncryptedDialog(dialogId)) return true
-        return getHidden(account).contains(dialogId)
+        return if (isWhitelistMode) {
+            !getVisible(account).contains(dialogId)
+        } else {
+            getHidden(account).contains(dialogId)
+        }
     }
 
     fun getHidden(account: Int): Set<Long> {
-        val cache = hiddenCache ?: loadAll().also { hiddenCache = it }
+        val cache = hiddenCache ?: loadAll("hiddenChats").also { hiddenCache = it }
         return cache[account] ?: emptySet()
-    }
-
-    private fun loadAll(): Map<Int, Set<Long>> {
-        val map = HashMap<Int, Set<Long>>()
-        for (a in 0 until UserConfig.MAX_ACCOUNT_COUNT) {
-            val stored = prefs.getStringSet("hiddenChats$a", null) ?: continue
-            map[a] = stored.mapNotNull { it.toLongOrNull() }.toHashSet()
-        }
-        return map
     }
 
     fun setHidden(account: Int, ids: Collection<Long>) {
         prefs.edit { putStringSet("hiddenChats$account", ids.map(Long::toString).toHashSet()) }
         hiddenCache = null
+    }
+
+    fun getVisible(account: Int): Set<Long> {
+        val cache = visibleCache ?: loadAll("visibleChats").also { visibleCache = it }
+        return cache[account] ?: emptySet()
+    }
+
+    fun setVisible(account: Int, ids: Collection<Long>) {
+        prefs.edit { putStringSet("visibleChats$account", ids.map(Long::toString).toHashSet()) }
+        visibleCache = null
+    }
+
+    fun getActiveList(account: Int): Set<Long> =
+        if (isWhitelistMode) getVisible(account) else getHidden(account)
+
+    fun setActiveList(account: Int, ids: Collection<Long>) {
+        if (isWhitelistMode) setVisible(account, ids) else setHidden(account, ids)
+    }
+
+    private fun loadAll(prefix: String): Map<Int, Set<Long>> {
+        val map = HashMap<Int, Set<Long>>()
+        for (a in 0 until UserConfig.MAX_ACCOUNT_COUNT) {
+            val stored = prefs.getStringSet("$prefix$a", null) ?: continue
+            map[a] = stored.mapNotNull { it.toLongOrNull() }.toHashSet()
+        }
+        return map
     }
 
     var hideSettings: Boolean

--- a/src/kotlin/ui/settings/ParanoiaActivity.kt
+++ b/src/kotlin/ui/settings/ParanoiaActivity.kt
@@ -28,7 +28,6 @@ class ParanoiaActivity : SettingsPageActivity() {
     override fun fillItems(items: ArrayList<UItem>, adapter: UniversalAdapter) {
         items.add(UItem.asShadow(LocaleController.getString(R.string.InuParanoiaModeInfo)))
 
-        val count = ParanoiaHelper.getHidden(currentAccount).size
         items.add(
             UItem.asButton(
                 SET_CODE,
@@ -41,12 +40,24 @@ class ParanoiaActivity : SettingsPageActivity() {
         )
         items.add(UItem.asShadow(LocaleController.getString(R.string.InuParanoiaExitCodeInfo)))
 
-
+        val whitelist = ParanoiaHelper.isWhitelistMode
+        val count = ParanoiaHelper.getActiveList(currentAccount).size
+        items.add(
+            UItem.asButton(
+                FILTERING_MODE,
+                R.drawable.inu_tabler_filter,
+                LocaleController.getString(R.string.InuParanoiaFilteringMode),
+                filteringModeLabel(whitelist),
+            )
+        )
         items.add(
             UItem.asButton(
                 SELECT_CHATS,
                 R.drawable.menu_hide_gift,
-                LocaleController.getString(R.string.InuParanoiaSelect),
+                LocaleController.getString(
+                    if (whitelist) R.string.InuParanoiaSelectShow
+                    else R.string.InuParanoiaSelect
+                ),
                 LocaleController.formatString(R.string.InuParanoiaCount, count)
             )
         )
@@ -83,6 +94,17 @@ class ParanoiaActivity : SettingsPageActivity() {
         when (item.id) {
             SELECT_CHATS -> openPicker()
             SET_CODE -> showCodeDialog()
+            FILTERING_MODE -> RadioItemOptions.show(
+                this, view,
+                listOf(
+                    LocaleController.getString(R.string.InuParanoiaFilteringModeBlacklist),
+                    LocaleController.getString(R.string.InuParanoiaFilteringModeWhitelist),
+                ),
+                if (ParanoiaHelper.isWhitelistMode) 1 else 0,
+            ) { which ->
+                ParanoiaHelper.isWhitelistMode = which == 1
+                listView.adapter.update(true)
+            }
             TOGGLE_DISGUISE -> toggleCheck(view, ParanoiaHelper.disguiseIcon) { ParanoiaHelper.disguiseIcon = it }
             TOGGLE_HIDE_OTHER_ACCOUNTS -> toggleCheck(view, ParanoiaHelper.hideOtherAccounts) { ParanoiaHelper.hideOtherAccounts = it }
             TOGGLE_DISABLE_NOTIFICATIONS -> toggleCheck(view, ParanoiaHelper.disableNotifications) { ParanoiaHelper.disableNotifications = it }
@@ -104,13 +126,17 @@ class ParanoiaActivity : SettingsPageActivity() {
 
     private fun openPicker() {
         val args = Bundle().apply {
-            putBoolean("isNeverShare", true)
+            if (ParanoiaHelper.isWhitelistMode) {
+                putBoolean("isAlwaysShare", true)
+            } else {
+                putBoolean("isNeverShare", true)
+            }
             putInt("chatAddType", 2)
         }
         val fragment = GroupCreateActivity(args)
-        fragment.select(ArrayList(ParanoiaHelper.getHidden(currentAccount)), false, false)
+        fragment.select(ArrayList(ParanoiaHelper.getActiveList(currentAccount)), false, false)
         fragment.setDelegate { _, _, ids ->
-            ParanoiaHelper.setHidden(currentAccount, ids)
+            ParanoiaHelper.setActiveList(currentAccount, ids)
             listView.adapter.update(true)
         }
         presentFragment(fragment)
@@ -138,7 +164,7 @@ class ParanoiaActivity : SettingsPageActivity() {
     }
 
     private fun tryEnableParanoia() {
-        if (!ParanoiaHelper.hasExitCode() || ParanoiaHelper.getHidden(currentAccount).isEmpty()) {
+        if (!ParanoiaHelper.hasExitCode() || ParanoiaHelper.getActiveList(currentAccount).isEmpty()) {
             BulletinFactory.of(this)
                 .createErrorBulletin(LocaleController.getString(R.string.InuParanoiaNeedSetup))
                 .show()
@@ -159,9 +185,15 @@ class ParanoiaActivity : SettingsPageActivity() {
     companion object {
         private val SELECT_CHATS = InuUtils.generateId()
         private val SET_CODE = InuUtils.generateId()
+        private val FILTERING_MODE = InuUtils.generateId()
         private val TOGGLE_DISGUISE = InuUtils.generateId()
         private val TOGGLE_HIDE_OTHER_ACCOUNTS = InuUtils.generateId()
         private val TOGGLE_DISABLE_NOTIFICATIONS = InuUtils.generateId()
         private val TOGGLE_HIDE_SETTINGS = InuUtils.generateId()
+
+        private fun filteringModeLabel(whitelist: Boolean): String = LocaleController.getString(
+            if (whitelist) R.string.InuParanoiaFilteringModeWhitelist
+            else R.string.InuParanoiaFilteringModeBlacklist
+        )
     }
 }

--- a/src/kotlin/ui/settings/RadioItemOptions.kt
+++ b/src/kotlin/ui/settings/RadioItemOptions.kt
@@ -4,6 +4,7 @@ import android.view.View
 import org.telegram.ui.ActionBar.BaseFragment
 import org.telegram.ui.Cells.TextCell
 import org.telegram.ui.Components.ItemOptions
+import org.telegram.ui.Components.RecyclerListView
 
 object RadioItemOptions {
     fun show(
@@ -14,6 +15,7 @@ object RadioItemOptions {
         onSelect: (Int) -> Unit,
     ) {
         val options = ItemOptions.makeOptions(fragment, anchor)
+        (anchor.parent as? RecyclerListView)?.getClipBackground(anchor)?.let(options::setScrimViewBackground)
         items.forEachIndexed { index, text ->
             options.addChecked(index == selectedIndex, text) {
                 if (index == selectedIndex) return@addChecked

--- a/src/kotlin/ui/settings/SettingsPageActivity.kt
+++ b/src/kotlin/ui/settings/SettingsPageActivity.kt
@@ -293,6 +293,7 @@ abstract class SettingsPageActivity : UniversalFragment() {
 
     override fun onLongClick(item: UItem, view: View, position: Int, x: Float, y: Float): Boolean {
         val opts = ItemOptions.makeOptions(this, view)
+        (view.parent as? UniversalRecyclerView)?.getClipBackground(view)?.let(opts::setScrimViewBackground)
         if (!addCopyLinkOption(opts, item)) return false
         opts.show()
         return true

--- a/src/res/values-ja/strings_inu.xml
+++ b/src/res/values-ja/strings_inu.xml
@@ -433,7 +433,11 @@
     <string name="InuParanoiaDisguiseInfo">ランチャーのアイコンと名前のみが変わります。Android の制限により、通知やアプリ内の名前は引き続き「Inugram」と表示されます。</string>
     <string name="InuParanoiaMode">パラノイアモード</string>
     <string name="InuParanoiaModeInfo">パラノイアモードでは、「危険な」チャットを隠し、必要に応じて標準アプリに偽装することで、誰かに端末を見られる事態に「備える」ことができます。</string>
+    <string name="InuParanoiaFilteringMode">フィルタリングモード</string>
+    <string name="InuParanoiaFilteringModeBlacklist">ブラックリスト</string>
+    <string name="InuParanoiaFilteringModeWhitelist">ホワイトリスト</string>
     <string name="InuParanoiaSelect">隠すチャット</string>
+    <string name="InuParanoiaSelectShow">表示するチャット</string>
     <string name="InuParanoiaSelectInfo">シークレットチャットは常に隠されます</string>
     <string name="InuParanoiaCount">%1$d 件のチャット</string>
     <string name="InuParanoiaExitCode">解除コード</string>

--- a/src/res/values-ru/strings_inu.xml
+++ b/src/res/values-ru/strings_inu.xml
@@ -437,7 +437,11 @@
     <string name="InuParanoiaDisguiseInfo">Меняются только иконка и имя в лаунчере. Из-за ограничений Android уведомления и имя внутри приложения по-прежнему показывают «Inugram».</string>
     <string name="InuParanoiaMode">Режим паранойи</string>
     <string name="InuParanoiaModeInfo">Режим паранойи позволяет «подготовиться» к тому, что кто-то заглянет в ваш телефон: он скрывает любые «опасные» чаты и при желании маскирует приложение под стандартное.</string>
+    <string name="InuParanoiaFilteringMode">Режим фильтрации</string>
+    <string name="InuParanoiaFilteringModeBlacklist">Чёрный список</string>
+    <string name="InuParanoiaFilteringModeWhitelist">Белый список</string>
     <string name="InuParanoiaSelect">Чаты для скрытия</string>
+    <string name="InuParanoiaSelectShow">Чаты для показа</string>
     <string name="InuParanoiaSelectInfo">Секретные чаты скрываются всегда</string>
     <string name="InuParanoiaCount">%1$d чатов</string>
     <string name="InuParanoiaExitCode">Код выхода</string>

--- a/src/res/values-zh-rCN/strings_inu.xml
+++ b/src/res/values-zh-rCN/strings_inu.xml
@@ -433,7 +433,11 @@
     <string name="InuParanoiaDisguiseInfo">仅更改启动器图标和名称。由于 Android 限制，通知和应用内名称仍显示「Inugram」。</string>
     <string name="InuParanoiaMode">偏执模式</string>
     <string name="InuParanoiaModeInfo">偏执模式让你为他人查看手机做好「准备」：隐藏任何「危险」聊天，并可选择伪装成原版应用。</string>
+    <string name="InuParanoiaFilteringMode">过滤模式</string>
+    <string name="InuParanoiaFilteringModeBlacklist">黑名单</string>
+    <string name="InuParanoiaFilteringModeWhitelist">白名单</string>
     <string name="InuParanoiaSelect">要隐藏的聊天</string>
+    <string name="InuParanoiaSelectShow">要显示的聊天</string>
     <string name="InuParanoiaSelectInfo">私密聊天始终隐藏</string>
     <string name="InuParanoiaCount">%1$d 个聊天</string>
     <string name="InuParanoiaExitCode">退出码</string>

--- a/src/res/values/strings_inu.xml
+++ b/src/res/values/strings_inu.xml
@@ -484,7 +484,11 @@
     <string name="InuDisguiseName" translatable="false">Telegram</string>
     <string name="InuParanoiaMode">Paranoia mode</string>
     <string name="InuParanoiaModeInfo">Paranoia mode lets you \"prepare\" for someone else checking your phone, by hiding any \"dangerous\" chats, and optionally disguising as the stock app.</string>
+    <string name="InuParanoiaFilteringMode">Filtering mode</string>
+    <string name="InuParanoiaFilteringModeBlacklist">Blacklist</string>
+    <string name="InuParanoiaFilteringModeWhitelist">Whitelist</string>
     <string name="InuParanoiaSelect">Chats to hide</string>
+    <string name="InuParanoiaSelectShow">Chats to show</string>
     <string name="InuParanoiaSelectInfo">Secret chats are always hidden</string>
     <string name="InuParanoiaCount">%1$d chats</string>
     <string name="InuParanoiaExitCode">Exit code</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paranoia mode now supports filtering modes, allowing users to toggle between blacklist (hide specific chats) and whitelist (display only selected chats) options

* **Localization**
  * Added translations for Japanese, Russian, and Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teidesu/inugram/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->