### PR TITLE
Add proxy toggle item to drawer & fix Proxy Settings style to match MD3

### DIFF
--- a/patches/bugfix/proxy-list-md3-sections.patch
+++ b/patches/bugfix/proxy-list-md3-sections.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew <kezin636@gmail.com>
+Date: Thu, 16 Jul 2026 12:32:04 +0300
+Subject: Fix MD3 sections style not applying in Proxy Settings list
+
+---
+ .../src/main/java/org/telegram/ui/ProxyListActivity.java     | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/TMessagesProj/src/main/java/org/telegram/ui/ProxyListActivity.java b/TMessagesProj/src/main/java/org/telegram/ui/ProxyListActivity.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/ui/ProxyListActivity.java
++++ b/TMessagesProj/src/main/java/org/telegram/ui/ProxyListActivity.java
+@@ -1008,27 +1008,22 @@ public class ProxyListActivity extends BaseFragment implements NotificationCente
+                     break;
+                 case VIEW_TYPE_TEXT_SETTING:
+                     view = new TextSettingsCell(mContext);
+-                    view.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+                     break;
+                 case VIEW_TYPE_HEADER:
+                     view = new HeaderCell(mContext);
+-                    view.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+                     break;
+                 case VIEW_TYPE_TEXT_CHECK:
+                     view = new TextCheckCell(mContext);
+-                    view.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+                     break;
+                 case VIEW_TYPE_INFO:
+                     view = new TextInfoPrivacyCell(mContext);
+                     break;
+                 case VIEW_TYPE_SLIDE_CHOOSER:
+                     view = new SlideChooseView(mContext);
+-                    view.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+                     break;
+                 case VIEW_TYPE_PROXY_DETAIL:
+                 default:
+                     view = new TextDetailProxyCell(mContext);
+-                    view.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+                     break;
+             }
+             view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, RecyclerView.LayoutParams.WRAP_CONTENT));

--- a/series
+++ b/series
@@ -219,3 +219,4 @@ bugfix/catch-shared-media-swipe.patch
 bugfix/recyclerlist-ripple.patch
 bugfix/popup-drag-select-high-ids.patch
 feature/web-preview-spoiler.patch
+bugfix/proxy-list-md3-sections.patch

--- a/src/kotlin/helpers/dialogs/DrawerHelper.kt
+++ b/src/kotlin/helpers/dialogs/DrawerHelper.kt
@@ -17,6 +17,7 @@ import desu.inugram.helpers.update.UpdateHelper
 import desu.inugram.ui.drawer.DrawerAddCell
 import desu.inugram.ui.drawer.DrawerLayoutAdapter
 import desu.inugram.ui.drawer.DrawerProfileCell
+import desu.inugram.ui.drawer.DrawerProxyCell
 import desu.inugram.ui.drawer.DrawerSwipeController
 import desu.inugram.ui.drawer.DrawerUserCell
 import desu.inugram.ui.drawer.SideMenultItemAnimator
@@ -26,6 +27,7 @@ import org.telegram.messenger.ApplicationLoader
 import org.telegram.messenger.FileLoader
 import org.telegram.messenger.ImageLoader
 import org.telegram.messenger.LocaleController.getString
+import org.telegram.tgnet.ConnectionsManager
 import org.telegram.messenger.MessagesController
 import org.telegram.messenger.NotificationCenter
 import org.telegram.messenger.R
@@ -49,6 +51,7 @@ import org.telegram.ui.LaunchActivity
 import org.telegram.ui.LoginActivity
 import org.telegram.ui.MainTabsActivity
 import org.telegram.ui.ProfileActivity
+import org.telegram.ui.ProxyListActivity
 import org.telegram.ui.SettingsActivity
 import org.telegram.ui.UpdateLayoutWrapper
 
@@ -59,6 +62,7 @@ object DrawerHelper {
     private var sideMenu: RecyclerListView? = null
     private var sideMenuContainer: FrameLayout? = null
     private var themeObserver: NotificationCenter.NotificationCenterDelegate? = null
+    private var proxyObserver: NotificationCenter.NotificationCenterDelegate? = null
     private var updateLayout: IUpdateLayout? = null
     private var updateObserver: NotificationCenter.NotificationCenterDelegate? = null
     private var updateObserverAccount: Int = -1
@@ -120,7 +124,7 @@ object DrawerHelper {
         val sm = RecyclerListView(context)
         sm.layoutManager = LinearLayoutManager(context)
         val itemAnimator = SideMenultItemAnimator(sm)
-        val newAdapter = DrawerLayoutAdapter(context, itemAnimator, drawerLayoutContainer)
+        val newAdapter = DrawerLayoutAdapter(context, itemAnimator, drawerLayoutContainer, ::applyProxyEnabled)
         adapter = newAdapter
         sideMenu = sm
         sm.setItemAnimator(itemAnimator)
@@ -157,6 +161,7 @@ object DrawerHelper {
         controller.setAllowOpenDrawer(true, false)
 
         installThemeObserver()
+        installProxyObserver()
         installUpdateLayout(context as? Activity, container, sm)
     }
 
@@ -348,6 +353,34 @@ object DrawerHelper {
         NotificationCenter.getGlobalInstance().addObserver(obs, NotificationCenter.reloadInterface)
     }
 
+    private fun installProxyObserver() {
+        if (proxyObserver != null) return
+        val obs = NotificationCenter.NotificationCenterDelegate { id, _, _ ->
+            if (id == NotificationCenter.proxySettingsChanged) {
+                adapter?.notifyDataSetChanged()
+            }
+        }
+        proxyObserver = obs
+        NotificationCenter.getGlobalInstance().addObserver(obs, NotificationCenter.proxySettingsChanged)
+    }
+
+    private fun applyProxyEnabled(enabled: Boolean) {
+        val proxy = SharedConfig.currentProxy ?: return
+        MessagesController.getGlobalMainSettings().edit()
+            .putBoolean("proxy_enabled", enabled)
+            .apply()
+        if (enabled) {
+            ConnectionsManager.setProxySettings(
+                true, proxy.address, proxy.port,
+                proxy.username, proxy.password, proxy.secret
+            )
+        } else {
+            ConnectionsManager.setProxySettings(false, "", 0, "", "", "")
+        }
+        NotificationCenter.getGlobalInstance()
+            .postNotificationName(NotificationCenter.proxySettingsChanged)
+    }
+
     private fun refreshTheme() {
         sideMenuContainer?.setBackgroundColor(Theme.getColor(Theme.key_chats_menuBackground))
         sideMenu?.let { applySideMenuColors(it) }
@@ -453,6 +486,11 @@ object DrawerHelper {
                 close()
             }
 
+            ITEM_PROXY -> {
+                nav.presentFragment(ProxyListActivity())
+                close()
+            }
+
             else -> close()
         }
     }
@@ -465,6 +503,7 @@ object DrawerHelper {
     private const val ITEM_CALLS = 10
     private const val ITEM_SAVED_MESSAGES = 11
     private const val ITEM_SETTINGS = 8
+    private const val ITEM_PROXY = DrawerLayoutAdapter.ITEM_PROXY
 
     @JvmStatic
     fun notifyDataChanged() {

--- a/src/kotlin/helpers/dialogs/DrawerHelper.kt
+++ b/src/kotlin/helpers/dialogs/DrawerHelper.kt
@@ -365,11 +365,11 @@ object DrawerHelper {
     }
 
     private fun applyProxyEnabled(enabled: Boolean) {
-        val proxy = SharedConfig.currentProxy ?: return
+        val proxy = if (enabled) SharedConfig.currentProxy else null
         MessagesController.getGlobalMainSettings().edit()
-            .putBoolean("proxy_enabled", enabled)
+            .putBoolean("proxy_enabled", enabled && proxy != null)
             .apply()
-        if (enabled) {
+        if (proxy != null) {
             ConnectionsManager.setProxySettings(
                 true, proxy.address, proxy.port,
                 proxy.username, proxy.password, proxy.secret

--- a/src/kotlin/ui/drawer/DrawerLayoutAdapter.kt
+++ b/src/kotlin/ui/drawer/DrawerLayoutAdapter.kt
@@ -16,6 +16,7 @@ import org.telegram.messenger.UserConfig
 import org.telegram.tgnet.TLRPC
 import org.telegram.ui.ActionBar.DrawerLayoutContainer
 import org.telegram.ui.ActionBar.Theme
+import org.telegram.messenger.SharedConfig
 import org.telegram.ui.Cells.DividerCell
 import org.telegram.ui.Cells.EmptyCell
 import org.telegram.ui.Components.RecyclerListView
@@ -24,6 +25,7 @@ class DrawerLayoutAdapter(
     private val mContext: Context,
     private val itemAnimator: SideMenultItemAnimator,
     private val mDrawerLayoutContainer: DrawerLayoutContainer,
+    private val onProxySwitchToggled: ((Boolean) -> Unit)? = null,
 ) : RecyclerListView.SelectionAdapter() {
 
     private val items = ArrayList<Item?>(11)
@@ -82,7 +84,7 @@ class DrawerLayoutAdapter(
 
     override fun isEnabled(holder: RecyclerView.ViewHolder): Boolean {
         val t = holder.itemViewType
-        return t == 3 || t == 4 || t == 5 || t == 6
+        return t == 3 || t == 4 || t == 5 || t == 6 || t == 7
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -92,6 +94,7 @@ class DrawerLayoutAdapter(
             3 -> DrawerActionCell(mContext)
             4 -> DrawerUserCell(mContext)
             5 -> DrawerAddCell(mContext)
+            7 -> DrawerProxyCell(mContext)
             else -> EmptyCell(mContext, AndroidUtilities.dp(8f))
         }
         view.layoutParams = RecyclerView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
@@ -121,6 +124,18 @@ class DrawerLayoutAdapter(
                 val cell = holder.itemView as DrawerUserCell
                 cell.setAccount(accountNumbers[position - 2])
             }
+
+            7 -> {
+                val cell = holder.itemView as DrawerProxyCell
+                var pos = position - 2
+                if (accountsShown) pos -= getAccountRowsCount()
+                val item = items[pos]
+                if (item != null) cell.bind(item.text ?: "", item.icon)
+                val hasProxies = SharedConfig.proxyList.isNotEmpty()
+                cell.setSwitchVisible(hasProxies)
+                cell.setChecked(SharedConfig.isProxyEnabled())
+                cell.onSwitchToggled = onProxySwitchToggled
+            }
         }
     }
 
@@ -138,7 +153,9 @@ class DrawerLayoutAdapter(
             }
             idx -= getAccountRowsCount()
         }
-        if (idx < 0 || idx >= items.size || items[idx] == null) return 2
+        if (idx < 0 || idx >= items.size) return 2
+        val id = items[idx]?.id ?: return 2
+        if (id == ITEM_PROXY) return 7
         return 3
     }
 
@@ -200,7 +217,12 @@ class DrawerLayoutAdapter(
         items.add(Item(6, LocaleController.getString(R.string.Contacts), R.drawable.msg_contacts))
         items.add(Item(10, LocaleController.getString(R.string.Calls), R.drawable.msg_calls))
         items.add(Item(11, LocaleController.getString(R.string.SavedMessages), R.drawable.msg_saved))
+        items.add(Item(ITEM_PROXY, LocaleController.getString(R.string.ProxySettings), R.drawable.outline_shield_check))
         items.add(Item(8, LocaleController.getString(R.string.Settings), R.drawable.msg_settings_old))
+    }
+
+    companion object {
+        const val ITEM_PROXY = 9
     }
 
     class Item private constructor(

--- a/src/kotlin/ui/drawer/DrawerProxyCell.kt
+++ b/src/kotlin/ui/drawer/DrawerProxyCell.kt
@@ -10,6 +10,7 @@ import android.view.ViewConfiguration
 import android.widget.FrameLayout
 import android.widget.TextView
 import org.telegram.messenger.AndroidUtilities
+import org.telegram.messenger.LocaleController
 import org.telegram.ui.ActionBar.Theme
 import org.telegram.ui.Components.BackupImageView
 import org.telegram.ui.Components.LayoutHelper
@@ -23,6 +24,7 @@ class DrawerProxyCell(context: Context) : FrameLayout(context) {
     private val checkBox: Switch
 
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+    private val isRTL get() = LocaleController.isRTL
 
     var onSwitchToggled: ((Boolean) -> Unit)? = null
 
@@ -34,7 +36,7 @@ class DrawerProxyCell(context: Context) : FrameLayout(context) {
         textView.setTextColor(Theme.getColor(Theme.key_chats_menuItemText))
         textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15f)
         textView.typeface = AndroidUtilities.bold()
-        textView.gravity = Gravity.CENTER_VERTICAL or Gravity.LEFT
+        textView.gravity = Gravity.CENTER_VERTICAL or (if (isRTL) Gravity.RIGHT else Gravity.LEFT)
 
         checkBox = Switch(context)
         checkBox.setColors(Theme.key_switchTrack, Theme.key_switchTrackChecked, Theme.key_chats_menuBackground, Theme.key_chats_menuBackground)
@@ -61,8 +63,9 @@ class DrawerProxyCell(context: Context) : FrameLayout(context) {
 
     private fun isInSwitchZone(x: Float): Boolean {
         if (checkBox.visibility != VISIBLE) return false
-        // hit zone: from the switch left edge (with extra padding) to the right edge of the cell
-        return x >= checkBox.left - AndroidUtilities.dp(12f)
+        // hit zone: from the switch edge (with extra padding) to the near edge of the cell
+        return if (isRTL) x <= checkBox.right + AndroidUtilities.dp(12f)
+        else x >= checkBox.left - AndroidUtilities.dp(12f)
     }
 
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {

--- a/src/kotlin/ui/drawer/DrawerProxyCell.kt
+++ b/src/kotlin/ui/drawer/DrawerProxyCell.kt
@@ -1,0 +1,119 @@
+package desu.inugram.ui.drawer
+
+import android.content.Context
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import android.widget.FrameLayout
+import android.widget.TextView
+import org.telegram.messenger.AndroidUtilities
+import org.telegram.ui.ActionBar.Theme
+import org.telegram.ui.Components.BackupImageView
+import org.telegram.ui.Components.LayoutHelper
+import org.telegram.ui.Components.Switch
+import kotlin.math.abs
+
+class DrawerProxyCell(context: Context) : FrameLayout(context) {
+
+    private val imageView: BackupImageView
+    private val textView: TextView
+    private val checkBox: Switch
+
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+
+    var onSwitchToggled: ((Boolean) -> Unit)? = null
+
+    init {
+        imageView = BackupImageView(context)
+        imageView.setColorFilter(PorterDuffColorFilter(Theme.getColor(Theme.key_chats_menuItemIcon), PorterDuff.Mode.SRC_IN))
+
+        textView = TextView(context)
+        textView.setTextColor(Theme.getColor(Theme.key_chats_menuItemText))
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15f)
+        textView.typeface = AndroidUtilities.bold()
+        textView.gravity = Gravity.CENTER_VERTICAL or Gravity.LEFT
+
+        checkBox = Switch(context)
+        checkBox.setColors(Theme.key_switchTrack, Theme.key_switchTrackChecked, Theme.key_chats_menuBackground, Theme.key_chats_menuBackground)
+        checkBox.isClickable = false
+        checkBox.isFocusable = false
+
+        addView(imageView, LayoutHelper.createFrame(24, 24f, Gravity.LEFT or Gravity.TOP, 19f, 12f, 0f, 0f))
+        addView(textView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT.toFloat(), Gravity.LEFT or Gravity.TOP, 72f, 0f, 70f, 0f))
+        addView(checkBox, LayoutHelper.createFrame(37, 24f, Gravity.RIGHT or Gravity.CENTER_VERTICAL, 0f, 0f, 22f, 0f))
+
+        // Switch draws a larger thumb/ripple than its measured bounds — allow it to overdraw.
+        setClipChildren(false)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        textView.setTextColor(Theme.getColor(Theme.key_chats_menuItemText))
+        imageView.setColorFilter(PorterDuffColorFilter(Theme.getColor(Theme.key_chats_menuItemIcon), PorterDuff.Mode.SRC_IN))
+        checkBox.setColors(Theme.key_switchTrack, Theme.key_switchTrackChecked, Theme.key_chats_menuBackground, Theme.key_chats_menuBackground)
+    }
+
+    private var switchDownX = -1f
+    private var inSwitchZone = false
+
+    private fun isInSwitchZone(x: Float): Boolean {
+        if (checkBox.visibility != VISIBLE) return false
+        // hit zone: from the switch left edge (with extra padding) to the right edge of the cell
+        return x >= checkBox.left - AndroidUtilities.dp(12f)
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        if (ev.action == MotionEvent.ACTION_DOWN) {
+            inSwitchZone = isInSwitchZone(ev.x)
+            if (inSwitchZone) {
+                parent?.requestDisallowInterceptTouchEvent(true)
+            }
+        }
+        return inSwitchZone
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (!inSwitchZone) return super.onTouchEvent(event)
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> {
+                switchDownX = event.x
+            }
+            MotionEvent.ACTION_UP -> {
+                if (abs(event.x - switchDownX) < touchSlop) {
+                    val newState = !checkBox.isChecked
+                    checkBox.setChecked(newState, true)
+                    onSwitchToggled?.invoke(newState)
+                }
+                inSwitchZone = false
+            }
+            MotionEvent.ACTION_CANCEL -> {
+                inSwitchZone = false
+            }
+            // ACTION_MOVE: consumed silently to prevent the row click from firing mid-drag
+        }
+        return true
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(
+            MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(AndroidUtilities.dp(48f), MeasureSpec.EXACTLY)
+        )
+    }
+
+    fun bind(text: CharSequence, iconRes: Int) {
+        textView.text = text
+        imageView.setImageResource(iconRes)
+    }
+
+    fun setChecked(checked: Boolean) {
+        checkBox.setChecked(checked, isAttachedToWindow)
+    }
+
+    fun setSwitchVisible(visible: Boolean) {
+        checkBox.visibility = if (visible) VISIBLE else GONE
+    }
+}


### PR DESCRIPTION
I thought that it would be kinda useful to have a proxy shortcut in a drawer (inspired by Telegram X). Had to do some workarounds to get it working (e.g. clickable zones to flip a visual switch, that kinda stuff).

If there's no proxy, the switch will be hidden. If you add at least one, the swtich will appear. If you just click the row, it will take you to the Proxy activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Proxy settings” entry to the navigation drawer, linking to the full proxy configuration screen.
  * Introduced an in-drawer proxy toggle that reflects the current proxy state.
  * Proxy toggle changes now take effect immediately, refreshing the drawer and applying proxy configuration right away.
* **Bug Fixes**
  * Fixed proxy list UI styling on MD3 layouts by removing forced background overrides for affected proxy list sections/cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->