### PR TITLE
display ultra hdr photos on supported screens

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -154,6 +154,7 @@ most things are toggleable in `Settings → Inugram`, with sensible opinionated 
 
 ## photo viewer
 
+- ultra HDR photos with HDR-capable displays - *based on [NagramX](https://github.com/risin42/NagramX)*
 - "hide with spoiler" toggle
 - "copy photo" / "copy frame" menu actions
 - show dc + platform of the photo in menu

--- a/patches/feature/hdr-images.patch
+++ b/patches/feature/hdr-images.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dubzer <me@dubzer.dev>
+Date: Tue, 25 Aug 2026 16:13:37 +0300
+Subject: Display Ultra HDR images on supported screens
+
+---
+ .../src/main/java/org/telegram/ui/PhotoViewer.java   | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+index 0000000..0000000 100644
+--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
++++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+@@ -884,7 +884,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+ 
+     public BlurringShader.BlurManager blurManager;
+     private BlurringShader.StoryBlurDrawer shadowBlurer;
+-    private WindowManager.LayoutParams windowLayoutParams;
++    public WindowManager.LayoutParams windowLayoutParams;
+     public FrameLayoutDrawer containerView;
+     private PhotoViewerWebView photoViewerWebView;
+     public FrameLayout windowView;
+@@ -2012,8 +2012,8 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+     private BlurringShader.ThumbBlurer centerBlur = new BlurringShader.ThumbBlurer(1, this::invalidateBlur);
+     private BlurringShader.ThumbBlurer rightBlur = new BlurringShader.ThumbBlurer(1, this::invalidateBlur);
+     private boolean leftImageIsVideo;
+-    private boolean centerImageIsVideo;
+-    private boolean centerImageIsLivePhoto;
++    public boolean centerImageIsVideo;
++    public boolean centerImageIsLivePhoto;
+     private boolean rightImageIsVideo;
+     private boolean centerImageTransformLocked = false;
+     private Matrix centerImageTransform = new Matrix();
+@@ -7791,6 +7791,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+                 if (paintingOverlay.getVisibility() == View.VISIBLE) {
+                     containerView.requestLayout();
+                 }
++                desu.inugram.helpers.media.PhotoViewerHelper.updateHdrMode(this);
+             }
+             if (imageReceiver == centerImage && set && placeProvider != null && placeProvider.scaleToFill() && !ignoreDidSetImage && sendPhotoType != SELECT_TYPE_AVATAR && sendPhotoType != SELECT_TYPE_STICKER) {
+                 if (!wasLayout) {
+@@ -16000,6 +16001,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+         }
+ 
+         if (!sameImage) {
++            desu.inugram.helpers.media.PhotoViewerHelper.clearHdrMode(this);
+             draggingDown = false;
+             translationX = 0;
+             translationY = 0;
+@@ -16157,6 +16159,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+                 videoFrameBitmap = null;
+             }
+         }
++        desu.inugram.helpers.media.PhotoViewerHelper.updateHdrMode(this);
+         currentImageHasFace = 0;
+         currentImageFaceKey = null;
+         inu_waitingForFacesOpen = false;
+@@ -18231,6 +18234,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+             qualityPicker.cancelButton.callOnClick();
+             return;
+         }
++        desu.inugram.helpers.media.PhotoViewerHelper.clearHdrMode(this);
+         isVisibleOrAnimating = false;
+         openedFullScreenVideo = false;
+         try {
+@@ -18923,6 +18927,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+ 
+     public void onResume() {
+         redraw(0); //workaround for camera bug
++        desu.inugram.helpers.media.PhotoViewerHelper.updateHdrMode(this);
+         if (videoPlayer != null) {
+             videoPlayer.seekTo(videoPlayer.getCurrentPosition() + 1);
+             if (playerLooping) {
+@@ -18937,6 +18942,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
+     public void onConfigurationChanged(Configuration newConfig) {}
+ 
+     public void onPause() {
++        desu.inugram.helpers.media.PhotoViewerHelper.clearHdrMode(this);
+         if (currentAnimation != null) {
+             closePhoto(false, false);
+             return;

--- a/series
+++ b/series
@@ -277,3 +277,4 @@ bugfix/video-stream-cancel-restart.patch
 feature/hd-bluetooth-call-audio.patch
 bugfix/video-bubble-progress.patch
 bugfix/glass-panel-keyboard-tint.patch
+feature/hdr-images.patch

--- a/src/kotlin/InuConfig.kt
+++ b/src/kotlin/InuConfig.kt
@@ -142,6 +142,9 @@ object InuConfig {
     @JvmField
     val PREDICTIVE_BACK_MODE = PredictiveBackModeItem()
 
+    @JvmField
+    val HDR_IMAGES = BoolItem("hdr_images", true, exportable = false)
+
     class TextSpoilerModeItem : IntItem("text_spoiler_mode", SIMPLE) {
         companion object {
             const val DEFAULT = 0

--- a/src/kotlin/helpers/media/PhotoViewerHelper.kt
+++ b/src/kotlin/helpers/media/PhotoViewerHelper.kt
@@ -1,8 +1,10 @@
 package desu.inugram.helpers.media
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.os.Build
 import android.util.TypedValue
 import android.view.View
 import android.widget.FrameLayout
@@ -36,6 +38,50 @@ object PhotoViewerHelper {
 
     private var footerGap: View? = null
     private var footerItem: ActionBarMenuSubItem? = null
+
+    @JvmStatic
+    fun clearHdrMode(viewer: PhotoViewer) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
+        setHdrMode(viewer, false)
+    }
+
+    @JvmStatic
+    fun updateHdrMode(viewer: PhotoViewer) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
+        if (
+            !InuConfig.HDR_IMAGES.value ||
+            viewer.centerImageIsVideo ||
+            viewer.centerImageIsLivePhoto ||
+            viewer.parentActivity?.display?.isHdr != true
+        ) {
+            clearHdrMode(viewer)
+            return
+        }
+
+        val bitmap = viewer.centerImage.bitmap
+        val enabled = bitmap != null && !bitmap.isRecycled && bitmap.hasGainmap()
+        setHdrMode(viewer, enabled)
+    }
+
+    private fun setHdrMode(viewer: PhotoViewer, enabled: Boolean) {
+        val params = viewer.windowLayoutParams ?: return
+        if (enabled) {
+            if (params.colorMode == ActivityInfo.COLOR_MODE_HDR) return
+            params.setColorMode(ActivityInfo.COLOR_MODE_HDR)
+        } else {
+            if (params.colorMode != ActivityInfo.COLOR_MODE_HDR) return
+            params.setColorMode(ActivityInfo.COLOR_MODE_DEFAULT)
+        }
+
+        val window = viewer.windowView ?: return
+        if (window.parent == null) return
+        val windowManager = viewer.parentActivity?.windowManager ?: return
+        try {
+            windowManager.updateViewLayout(window, params)
+        } catch (e: Exception) {
+            FileLog.e(e)
+        }
+    }
 
     @JvmStatic
     fun gifAsVideo(msg: MessageObject?): Boolean = msg != null && msg.isNewGif && InuConfig.GIF_SEEKBAR.value


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Added Ultra HDR photo support in the photo viewer on Android 14+ devices with HDR-capable displays.
  * HDR mode is automatically enabled for compatible photos and disabled when unsupported or viewing videos.
  * Added a setting to control HDR photo support, enabled by default.
  * Documented Ultra HDR compatibility in the feature list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ultra HDR photo support in the photo viewer on compatible HDR displays.
  * HDR mode is automatically enabled for supported photos and cleared when viewing videos, live photos, or leaving the viewer.
  * Added a setting to control HDR photo support, enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->